### PR TITLE
Add OnError support in Catch so errors to bubble up to your own observable code.

### DIFF
--- a/Assets/Plugins/Unicache/Scripts/FileCache.cs
+++ b/Assets/Plugins/Unicache/Scripts/FileCache.cs
@@ -156,7 +156,11 @@ namespace Unicache
                         .Select(data => command.SetData(data))
                 )
                 .Do(command => this.AsyncDeleteAndSetCache(obj, command))
-                .Catch<Command, Exception>(exception => Observable.Never<Command>())
+	            .Catch<Command, Exception>(exception =>
+	            {
+		            this.ResultQueue.OnError(exception);
+		            return Observable.Never<Command>();
+	            })
                 .Subscribe(command => this.ResultQueue.OnNext(command))
                 .AddTo(obj);
         }


### PR DESCRIPTION
The following code sample doesn't invoke the `onError` scope without this update.

```
var uri = "badURIaddress";
var observable = _fileCache.Fetch(uri).ByteToTexture2D();

observable.Subscribe(
	onNext: tex =>
	{
		if (IsValidTexture(tex))
		{
			Debug.Log($"Successful access to texture! ");
			Debug.Log($"Is \"ID\": \"{uri}\" Cached? : {_fileCache.HasCache(uri).ToString().ToUpper()}");
		}
	},
	onError: err =>
	{
		Debug.LogError($"Unable to retrieve ID: \"{uri}\": {err}");
		Debug.LogWarning(
			$"Something bad happened.");
	});
```

```
public static bool IsValidTexture(Texture2D texture)
{
	//unity returns an 4x4 entirely white texture when an empty file is passed
	//unity returns an 8x8 question mark texture when garbage data is passed into DownloadHandlerTexture.GetContent in the DownloadAsync call
	return (texture?.height > 8 || texture?.width > 8);
}
```